### PR TITLE
Fixes the loading animation on Browse

### DIFF
--- a/src/Components/Button.tsx
+++ b/src/Components/Button.tsx
@@ -218,8 +218,8 @@ export class Button extends Component<ButtonProps, ButtonState> {
 
   render() {
     const { borderRadius = 28, children, showCheckMark, disabled, loading, showChevron, rotateChevron, ...rest } = this.props
-    let { px, size, height } = this.getSize()
-    height = this.props.height ?? height
+    const { px, size, height } = this.getSize()
+    const buttonHeight = this.props.height ?? height
     const variantColors = getColorsForVariant(this.props.variant)
     const { current, previous } = this.state
     const from = disabled ? variantColors[DisplayState.Disabled] : variantColors[previous]
@@ -245,7 +245,7 @@ export class Button extends Component<ButtonProps, ButtonState> {
             disabled={disabled}
           >
             <Flex flexDirection="row">
-              <AnimatedContainer disabled={disabled} {...rest} style={{ ...props, borderRadius, height }} px={px}>
+              <AnimatedContainer disabled={disabled} {...rest} style={{ ...props, borderRadius, height: buttonHeight }} px={px}>
                 {!loading && (
                   <>
                     <Sans color={to.color} size={size}>

--- a/src/Scenes/Browse/Browse.tsx
+++ b/src/Scenes/Browse/Browse.tsx
@@ -131,8 +131,8 @@ export const Browse = (props: any) => {
   }, [props.screenProps.browseFilter])
 
   const insets = useSafeArea()
-  const loaderStyle = useSpring({ opacity: loading || !data ? 1 : 0 })
-  const productsBoxStyle = useSpring({ opacity: loading || !data ? 0 : 1 })
+  const loaderStyle = useSpring({ opacity: loading && !data ? 1 : 0 })
+  const productsBoxStyle = useSpring({ opacity: loading && !data ? 0 : 1 })
   const { navigation } = props
   const categories = (data && data.categories) || []
   const filtersButtonBottom = 16

--- a/src/Scenes/Browse/Filters.tsx
+++ b/src/Scenes/Browse/Filters.tsx
@@ -15,11 +15,11 @@ export const Filters = (props: any) => {
   const [sortFilter, setSortFilter] = useState(currentSortFilter)
   const [sizeFilters, setSizeFilters] = useState(currentSizeFilters)
 
-  const handleCancelBtnPressed = async () => {
+  const handleCancelBtnPressed = () => {
     props.navigation.dismiss()
   }
 
-  const handleApplyBtnPressed = async () => {
+  const handleApplyBtnPressed = () => {
     props.navigation.navigate('Browse', { sortFilter, sizeFilters })
   }
 


### PR DESCRIPTION
I added some logic in my previous PR to try to show the loading animation when we update a filter but this made it so that when the user scrolled down and a request was made to fetch more products, the loading animation would show up again.

I decided to revert this so that the behavior is the same as before.