### PR TITLE
Updates overlays

### DIFF
--- a/src/Components/FixedBackArrow.tsx
+++ b/src/Components/FixedBackArrow.tsx
@@ -6,7 +6,7 @@ import { TouchableOpacity } from "react-native"
 import { Box } from "./Box"
 import { themeProps } from "./Theme"
 
-type FixedBackArrowVariant = "blackBackground" | "whiteBackground"
+type FixedBackArrowVariant = "blackBackground" | "whiteBackground" | "black04Background"
 
 export const FixedBackArrow: React.FC<{
   navigation: any
@@ -14,7 +14,7 @@ export const FixedBackArrow: React.FC<{
 }> = ({ navigation, variant }) => {
   const getColorsForVariant = (variant: FixedBackArrowVariant) => {
     const {
-      colors: { black100, white100, black15 },
+      colors: { black100, white100, black15, black04 },
     } = themeProps
 
     switch (variant) {
@@ -26,6 +26,11 @@ export const FixedBackArrow: React.FC<{
       case "whiteBackground":
         return {
           backgroundColor: white100,
+          arrowColor: black100,
+        }
+      case "black04Background":
+        return {
+          backgroundColor: black04,
           arrowColor: black100,
         }
       default:
@@ -57,7 +62,7 @@ const Wrapper = styled(Box)`
   position: absolute;
   top: 50;
   left: 7;
-  z-index: 100;
+  z-index: 50;
 `
 
 const ArrowWrapper = styled(Flex)`

--- a/src/Components/PopUp.tsx
+++ b/src/Components/PopUp.tsx
@@ -116,7 +116,7 @@ export const PopUp: React.FC<PopUpProps> = ({ data, show, insetsBottom }) => {
               {buttonText}
             </Button>
           </Flex>
-          <Spacer mb={insetsBottom ? 6 : 2} />
+          <Spacer mb={insetsBottom ? 4 : 0} />
         </Box>
       </AnimatedPopUp>
       {show && <AnimatedOuterWrapper style={{ backgroundColor: animation.backgroundColor }} />}
@@ -127,9 +127,9 @@ export const PopUp: React.FC<PopUpProps> = ({ data, show, insetsBottom }) => {
 const OuterWrapper = styled(Box)`
   position: absolute;
   flex: 1;
-  height: 100%;
-  width: 100%;
+  top: 0;
   bottom: 0;
+  right: 0;
   left: 0;
   z-index: 99;
 `

--- a/src/Scenes/Product/Product.tsx
+++ b/src/Scenes/Product/Product.tsx
@@ -1,5 +1,5 @@
 import { GET_PRODUCT } from "App/Apollo/Queries"
-import { Box, Container, PopUp, Spacer, VariantSizes } from "App/Components"
+import { Box, Container, PopUp, Spacer, VariantSizes, FixedBackArrow } from "App/Components"
 import { Loader } from "App/Components/Loader"
 import { PopUpProps } from "App/Components/PopUp"
 import { GetProduct, GetProduct_product } from "App/generated/GetProduct"
@@ -140,16 +140,7 @@ export const Product = screenTrack(props => {
 
   return (
     <Container insetsTop={false}>
-      <ArrowWrapper>
-        <TouchableOpacity
-          onPress={() => {
-            navigation.goBack()
-          }}
-        >
-          <ArrowBackground showVariantPicker={showVariantPicker} />
-          <BackArrowIcon color={showVariantPicker ? color("white100") : color("black100")} />
-        </TouchableOpacity>
-      </ArrowWrapper>
+      <FixedBackArrow navigation={navigation} variant={showVariantPicker ? "blackBackground" : "black04Background"} />
       <FlatList
         ListHeaderComponent={() => <Spacer mb={insets.top} />}
         data={sections}
@@ -198,6 +189,7 @@ const VariantPickerWrapper = styled(Box)`
   left: 0;
   width: 100%;
   height: ${variantPickerHeight};
+  z-index: 4;
 `
 
 const Overlay = styled.View`
@@ -207,23 +199,6 @@ const Overlay = styled.View`
   left: 0;
   bottom: 0;
   right: 0;
-`
-
-const ArrowWrapper = styled(Box)`
-  position: absolute;
-  top: 60;
-  left: 20;
-  z-index: 1000;
-`
-
-const ArrowBackground = styled(Box)`
-  width: 30;
-  height: 30;
-  position: absolute;
-  background-color: ${p => (p.showVariantPicker ? color("black100") : color("black04"))};
-  border-radius: 40;
-  left: -6;
-  top: -1;
 `
 
 const VariantWantWrapper = styled(Box)`


### PR DESCRIPTION
<img width="443" alt="Screen Shot 2020-03-03 at 10 56 34 AM" src="https://user-images.githubusercontent.com/21182806/75794175-6b6ecb00-5d3e-11ea-953a-d0db79d998c5.png">

- Popup overlay now covers entire screen
- Uses FixedArrowButton for Product back arrow