### PR TITLE
Adds pollInterval to refetch payment & shipping information to accoun…

### DIFF
--- a/src/Scenes/Account/PaymentAndShipping/PaymentAndShipping.tsx
+++ b/src/Scenes/Account/PaymentAndShipping/PaymentAndShipping.tsx
@@ -80,9 +80,12 @@ export const createBillingAddress = billingInfo => {
 }
 
 export const PaymentAndShipping: React.FC<{ navigation: any }> = ({ navigation }) => {
-  const { loading, error, data } = useQuery(GET_PAYMENT_DATA)
+  const { loading, error, data } = useQuery(GET_PAYMENT_DATA, {
+    // Refetch query every second to account for chargebee webhook updates
+    pollInterval: 1000
+  })
 
-  if (loading) {
+  if (!data && loading) {
     return <Loader />
   }
 


### PR DESCRIPTION
This PR is to account for the changes in: https://github.com/seasons/monsoon/pull/224

We are now using a chargebee webhook to listen for updates when a user changes their payment information. however, it could be the case that the webhook gets called after the user clicks `Save` and returns to the display screen which meant that their old payment information would still be there.

To fix this, I added a `pollInterval` to the `GetPaymentData` query to fetch the information every second. Not sure if this would lead to too many queries but i can adjust the interval as needed

Demo:
![2020-03-03 19 44 30](https://user-images.githubusercontent.com/26048121/75833733-f2946100-5d87-11ea-8cec-28802265c5a3.gif)
