### PR TITLE
Fix reservation feedback flow to show

### DIFF
--- a/src/Scenes/Home/Home.tsx
+++ b/src/Scenes/Home/Home.tsx
@@ -1,4 +1,4 @@
-import { Box, Sans } from "App/Components"
+import { Box } from "App/Components"
 import { Loader } from "App/Components/Loader"
 import { color } from "App/utils"
 import { NetworkContext } from "App/NetworkProvider"
@@ -9,7 +9,6 @@ import { ReservationFeedbackPopUp, ReservationFeedbackReminder } from "../Reserv
 import gql from "graphql-tag"
 import React, { useEffect, useState, useContext } from "react"
 import { useQuery } from "react-apollo"
-import * as Animatable from "react-native-animatable"
 import { useSafeArea } from "react-native-safe-area-context"
 import SplashScreen from "react-native-splash-screen"
 import styled from "styled-components/native"
@@ -179,7 +178,6 @@ export const Home = screenTrack()(({ navigation }) => {
   const { loading, error, data, refetch } = useQuery(GET_HOMEPAGE, {})
   const [showSplash, setShowSplash] = useState(true)
   const network = useContext(NetworkContext)
-  const insets = useSafeArea()
 
   useEffect(() => {
     if (!loading && showSplash) {
@@ -221,8 +219,6 @@ export const Home = screenTrack()(({ navigation }) => {
 
   const reservationFeedback = data?.reservationFeedback
   const shouldRequestFeedback = data?.me?.customer?.shouldRequestFeedback
-  console.log("RESV FEEDBACK", reservationFeedback)
-  console.log("SHOULD REQ:", shouldRequestFeedback)
 
   const goToReservationFeedbackScreen = () => {
     navigation.navigate("Modal", {

--- a/src/Scenes/ReservationFeedback/Components/ReservationFeedbackPopUp.tsx
+++ b/src/Scenes/ReservationFeedback/Components/ReservationFeedbackPopUp.tsx
@@ -56,7 +56,6 @@ export const ReservationFeedbackPopUp: React.FC<ReservationFeedbackPopUpProps> =
   show,
   onSelectedRating,
 }) => {
-  console.log("RESV FEEDBACK POPUP SHOW")
   const tracking = useTracking()
   const [mounted, setMounted] = useState(false)
   const [selectedIndex, setSelectedIndex] = useState(null)
@@ -110,8 +109,6 @@ export const ReservationFeedbackPopUp: React.FC<ReservationFeedbackPopUpProps> =
       onSelectedRating()
     }
   }
-  console.log("WINDOW HEIGHT VS HEIGHT", windowHeight, height)
-  console.log("TRANSLATE Y:", show && mounted ? windowHeight - height : windowHeight)
   return (
     <>
       <AnimatedPopUp style={{ transform: [{ translateY: animation.translateY }] }} color={color("white100")}>

--- a/src/Scenes/ReservationFeedback/Components/ReservationFeedbackReminder.tsx
+++ b/src/Scenes/ReservationFeedback/Components/ReservationFeedbackReminder.tsx
@@ -14,7 +14,6 @@ export const ReservationFeedbackReminder: React.FC<ReservationFeedbackHeaderProp
   onPress,
   reservationFeedback,
 }) => {
-  console.log("RESV FEEDBACK REMINDER")
   const tracking = useTracking()
   const { feedbacks } = reservationFeedback
   const incompleteFeedbackIndex = feedbacks.findIndex(feedback => !feedback.isCompleted)


### PR DESCRIPTION
## Changes

- Due to the new layout of the home screen, even though reservation feedbacks were being created on the backend, it was being shown in the background in `Home`
- This PR fixes the display so that it shows again
- I also tested the whole flow again and responses are being recorded accordingly

## Screenshots

![Simulator Screen Shot - iPhone 11 - 2020-06-08 at 15 41 37](https://user-images.githubusercontent.com/26048121/84076054-1ed10680-a9a3-11ea-8553-90765528fdd6.png)
<img width="1436" alt="Screen Shot 2020-06-08 at 4 14 12 PM" src="https://user-images.githubusercontent.com/26048121/84076081-27c1d800-a9a3-11ea-9de1-c473652a1a3d.png">


## Checklist


- [Asana ticket](https://app.asana.com/0/1141411134053249/1173760343948305) now ready for QA
