### PR TITLE
Fixes authorize issue and bag issue

### DIFF
--- a/src/Navigation/AuthContext.ts
+++ b/src/Navigation/AuthContext.ts
@@ -5,6 +5,7 @@ export const useAuthContext = () => useContext(AuthContext)
 const AuthContext = React.createContext({
   signIn: (session: string) => null,
   signOut: () => null,
+  resetStore: () => null,
   userSession: null,
   authState: { authInitializing: true, isSignedIn: false, userSession: null },
 })

--- a/src/Navigation/AuthProvider.tsx
+++ b/src/Navigation/AuthProvider.tsx
@@ -26,6 +26,7 @@ export interface AuthProviderRef {
   authContext: () => {
     signIn: (session: any) => Promise<void>
     signOut: () => Promise<void>
+    resetStore: () => void
     authState: any
     userSession: any
   }
@@ -103,6 +104,9 @@ export const AuthProvider = React.forwardRef<AuthProviderRef, AuthProviderProps>
         RNPusherPushNotifications.clearAllState()
         analytics.reset()
         dispatch({ type: "SIGN_OUT" })
+        apolloClient.resetStore()
+      },
+      resetStore: () => {
         apolloClient.resetStore()
       },
       authState,

--- a/src/Scenes/Account/__tests__/Account-tests.tsx
+++ b/src/Scenes/Account/__tests__/Account-tests.tsx
@@ -13,6 +13,7 @@ beforeEach(() => {
   const authContextValues = {
     signIn: () => null,
     signOut: () => null,
+    resetStore: () => null,
     userSession: null,
     authState: { authInitializing: true, isSignedIn: false, userSession: "1234" },
   }

--- a/src/Scenes/Bag/Bag.tsx
+++ b/src/Scenes/Bag/Bag.tsx
@@ -47,14 +47,17 @@ export const Bag = screenTrack()((props) => {
   )
 
   const { data, refetch } = useQuery(GET_BAG)
+  const me = data?.me
+  const customerStatus = me?.customer?.status
   useEffect(() => {
     if (data) {
       setIsLoading(false)
     }
-    const status = data?.me?.customer?.status
-    if (!!status && !(status === "Active" || status === "Paused")) {
+    if (!!customerStatus && !(customerStatus === "Active" || customerStatus === "Paused")) {
       setDisabledTabs(["Bag", "History"])
       setCurrentView(BagView.Saved)
+    } else {
+      setDisabledTabs([])
     }
   }, [data])
 
@@ -128,8 +131,6 @@ export const Bag = screenTrack()((props) => {
     refetch()
     setRefreshing(false)
   }
-
-  const me = data?.me
 
   const items =
     me?.bag?.map((item) => ({
@@ -225,7 +226,6 @@ export const Bag = screenTrack()((props) => {
   const bagIsFull = bagCount === BAG_NUM_ITEMS
 
   const pauseRequest = me?.customer?.membership?.pauseRequests?.[0]
-  const customerStatus = me?.customer?.status
   const pausePending = pauseRequest?.pausePending
   let pauseStatus: PauseStatus = "active"
 

--- a/src/Scenes/Bag/__tests__/Bag-tests.tsx
+++ b/src/Scenes/Bag/__tests__/Bag-tests.tsx
@@ -26,6 +26,7 @@ beforeEach(() => {
   const authContextValues = {
     signIn: () => null,
     signOut: () => null,
+    resetStore: () => null,
     userSession: null,
     authState: { authInitializing: true, isSignedIn: false, userSession: "1234" },
   }

--- a/src/Scenes/CreateAccount/Admitted/ChoosePlanPane/ChoosePlanPane.tsx
+++ b/src/Scenes/CreateAccount/Admitted/ChoosePlanPane/ChoosePlanPane.tsx
@@ -13,6 +13,7 @@ import stripe from "tipsi-stripe"
 import * as Sentry from "@sentry/react-native"
 
 import { PlanTile } from "./PlanTile"
+import { GET_BAG } from "App/Scenes/Bag/BagQueries"
 
 const PAYMENT_CHECKOUT = gql`
   mutation applePayCheckout($planID: String!, $token: StripeToken!) {
@@ -50,6 +51,11 @@ export const ChoosePlanPane: React.FC<ChoosePlanPaneProps> = ({ plans, setNextSt
       showPopUp(popUpData)
       setIsMutating(false)
     },
+    refetchQueries: [
+      {
+        query: GET_BAG,
+      },
+    ],
   })
 
   useEffect(() => {
@@ -87,6 +93,7 @@ export const ChoosePlanPane: React.FC<ChoosePlanPaneProps> = ({ plans, setNextSt
               planID: selectedPlan.planID,
               token: token,
             },
+            awaitRefetchQueries: true,
           })
           // You should complete the operation by calling
           stripe.completeApplePayRequest()

--- a/src/Scenes/CreateAccount/CreateAccount.tsx
+++ b/src/Scenes/CreateAccount/CreateAccount.tsx
@@ -9,6 +9,7 @@ import { Dimensions, FlatList, Modal } from "react-native"
 import { ChoosePlanPane, WelcomePane } from "./Admitted"
 import { CreateAccountPane, GetMeasurementsPane, SendCodePane, TriagePane, VerifyCodePane } from "./Undetermined"
 import { WaitlistedPane } from "./Waitlisted"
+import { useAuthContext } from "App/Navigation/AuthContext"
 
 interface CreateAccountProps {
   navigation: any
@@ -78,6 +79,7 @@ const statesFor = (userState: UserState): State[] => {
 
 export const CreateAccount: React.FC<CreateAccountProps> = screenTrack()(({ navigation, route }) => {
   const { data } = useQuery(GET_PLANS)
+  const { resetStore } = useAuthContext()
   const initialState: State = get(route?.params, "initialState", State.CreateAccount)
   const initialUserState: UserState = get(route?.params, "initialUserState", UserState.Undetermined)
 
@@ -181,13 +183,19 @@ export const CreateAccount: React.FC<CreateAccountProps> = screenTrack()(({ navi
       <Modal visible={currentState === State.Welcome} animated>
         <WelcomePane
           onPressGetStarted={() => {
+            resetStore()
             navigation.goBack()
           }}
         />
       </Modal>
 
       <Modal visible={currentState === State.Waitlisted} animated>
-        <WaitlistedPane onPressFinish={() => navigation.goBack()} />
+        <WaitlistedPane
+          onPressFinish={() => {
+            resetStore()
+            navigation.goBack()
+          }}
+        />
       </Modal>
     </>
   )

--- a/src/Scenes/CreateAccount/Undetermined/TriagePane/TriagePane.tsx
+++ b/src/Scenes/CreateAccount/Undetermined/TriagePane/TriagePane.tsx
@@ -53,7 +53,10 @@ export const TriagePane: React.FC<TriagePaneProps> = ({ check, onTriageComplete 
 
   useEffect(() => {
     if ((checkStatus === CheckStatus.Waiting && check) || (checkStatus === CheckStatus.AwaitingRetry && check)) {
-      triageCustomer()
+      const runTriage = async () => {
+        await triageCustomer()
+      }
+      runTriage()
     }
   }, [check, checkStatus])
 

--- a/src/Scenes/CreateAccount/Undetermined/TriagePane/TriageProgressScreen.tsx
+++ b/src/Scenes/CreateAccount/Undetermined/TriagePane/TriageProgressScreen.tsx
@@ -22,16 +22,15 @@ const TriageProgressFooter = styled(Box)`
 export const TriageProgressScreen: React.FC<TriageProgressScreenProps> = ({ start, done }) => {
   const steps = ["Verifying Account", "Checking Sizes", "Confirming Availability"]
   const [currentStep, setCurrentStep] = useState(0)
+  const [stepsComplete, setStepsComplete] = useState(false)
 
   useEffect(() => {
     if (start) {
       const interval = setInterval(() => {
         setCurrentStep((currentStep) => {
-          console.log("Current step inside useEffect: ", currentStep)
           if (currentStep === steps.length - 1) {
             clearInterval(interval)
-            console.log("Calling done")
-            done?.()
+            setStepsComplete(true)
             return currentStep
           } else {
             return currentStep + 1
@@ -42,6 +41,12 @@ export const TriageProgressScreen: React.FC<TriageProgressScreenProps> = ({ star
       return () => clearInterval(interval)
     }
   }, [start])
+
+  useEffect(() => {
+    if (stepsComplete) {
+      done?.()
+    }
+  }, [stepsComplete])
 
   return (
     <Flex flexDirection="row" alignItems="center" alignContent="center" height="100%">


### PR DESCRIPTION
## Changes

## Problem 1
- **Bug**: I went through the new loading experience after sign-up, got automatically authorized, received a waitlisted confirmation view, and was then taken to my profile where I was authorized and could choose a plan.
- **Fix**: The `status` being passed to the `done` function wasn't actually being passed to the scope of the `setInterval` in the `TriageProgressScreen` component, therefore `status` was always `null` and the switch in the `done` function was always resulting to the default of `waitlisted`. I moved the call to the `done` function outside of the interval after the steps complete and now its working properly.

## Problem 2
- **Bug**: My bag doesn't immediately update after becoming a paid member. Only after closing the app and re-opening does it work
- **Fix**: I added a refetch query to the apple pay checkout mutation, I also added `resetStore` to the `AuthProvider` and I'm reseting the store once someone creates a new account. Also we weren't reseting the deactivated tabs in the `useEffect` in the bag once the customer's status was updated to `Active`

