### PR TITLE
adds event when user opens checkout

### DIFF
--- a/src/Scenes/CreateAccount/Admitted/ChoosePlanPane/ChoosePlanPane.tsx
+++ b/src/Scenes/CreateAccount/Admitted/ChoosePlanPane/ChoosePlanPane.tsx
@@ -14,6 +14,7 @@ import * as Sentry from "@sentry/react-native"
 
 import { PlanTile } from "./PlanTile"
 import { GET_BAG } from "App/Scenes/Bag/BagQueries"
+import { screenTrack, Schema, useTracking } from "App/utils/track"
 
 const PAYMENT_CHECKOUT = gql`
   mutation applePayCheckout($planID: String!, $token: StripeToken!) {
@@ -29,6 +30,7 @@ interface ChoosePlanPaneProps {
 const viewWidth = Dimensions.get("window").width
 
 export const ChoosePlanPane: React.FC<ChoosePlanPaneProps> = ({ plans, setNextState }) => {
+  const tracking = useTracking()
   const [selectedPlan, setSelectedPlan] = useState(plans?.[0])
   const insets = useSafeArea()
 
@@ -68,6 +70,11 @@ export const ChoosePlanPane: React.FC<ChoosePlanPaneProps> = ({ plans, setNextSt
     if (isMutating) {
       return
     }
+
+    tracking.trackEvent({
+      actionName: Schema.ActionNames.ChoosePlanTapped,
+      actionType: Schema.ActionTypes.Tap,
+    })
 
     setIsMutating(true)
 


### PR DESCRIPTION
In the transition to Apple Pay, we lost signal for when a user opens the checkout view. Previously the `Opened Hosted Checkout` event would fire. Until now, we fired nothing when they opened the apple pay checkout. 

This PR adds a `Choose Plan Tapped` event on the `CreateAccountModal`, re-establishing that signal.

cc @l2succes 