### PR TITLE
adds an iosAppVersion prop to all track calls

### DIFF
--- a/src/utils/config/index.ts
+++ b/src/utils/config/index.ts
@@ -13,6 +13,7 @@ export enum Env {
   APOLLO_KEY = "APOLLO_KEY",
   APPLE_MERCHANT_ID = "APPLE_MERCHANT_ID",
   STRIPE_KEY = "STRIPE_KEY",
+  IOS_APP_VERSION = "IOS_APP_VERSION",
 }
 
 const downloadAndSetNewStoredEnv = async () => {

--- a/src/utils/track/index.ts
+++ b/src/utils/track/index.ts
@@ -1,9 +1,8 @@
 import "../../setupAnalytics"
 
+import { config, Env } from "App/utils/config"
 import { Platform } from "react-native"
-import _track, {
-  Track as _Track, TrackingInfo, TrackingProp, useTracking as _useTracking
-} from "react-tracking"
+import _track, { Track as _Track, TrackingInfo, TrackingProp, useTracking as _useTracking } from "react-tracking"
 
 import analytics from "@segment/analytics-react-native"
 
@@ -90,7 +89,12 @@ export function screenTrack<P>(trackingInfo?: TrackingInfo<Schema.PageViewEvent,
 
   return _track(decorateTracking as any, {
     dispatch: (data) => {
-      const newData = { ...data, platform: Platform.OS, application: "harvest" } as any
+      const newData = {
+        ...data,
+        platform: Platform.OS,
+        application: "harvest",
+        iosAppVersion: config.get(Env.IOS_APP_VERSION),
+      } as any
       if (__DEV__) {
         console.log("[Event tracked]", JSON.stringify(newData, null, 2))
       }


### PR DESCRIPTION
We should keep track of the ios application version in the data we send to segment in order to better make sense of our funnels. 

For example, the step by step funnel for iOS isn't really reliable on mixpanel at the moment, because users were using different versions of the application, each of which had different events setup: https://mixpanel.com/report/2195096/view/361951/funnels#view/10027219/i-os-acquisition-funnel-detailed. 

This PR adds an `iosAppVersion` prop to all outgoing track calls.