### PR TITLE
feat: add outerwear rail to home bottom sheet

### DIFF
--- a/src/Scenes/Home/Components/HomeBottomSheet.tsx
+++ b/src/Scenes/Home/Components/HomeBottomSheet.tsx
@@ -28,8 +28,8 @@ const sectionsFrom = (data: any) => {
   if (data?.blogPosts) {
     sections.push({ type: SectionType.BlogPosts, results: data?.blogPosts })
   }
-  if (data?.justAddedTops?.length) {
-    sections.push({ type: SectionType.Products, results: data?.justAddedTops, title: "Just added tops" })
+  if (data?.justAddedOuterwear?.length) {
+    sections.push({ type: SectionType.Products, results: data?.justAddedOuterwear, title: "Just added outerwear" })
   }
   if (data?.homepage?.sections?.length) {
     sections.push(
@@ -44,6 +44,9 @@ const sectionsFrom = (data: any) => {
         })
         .filter(Boolean)
     )
+  }
+  if (data?.justAddedTops?.length) {
+    sections.push({ type: SectionType.Products, results: data?.justAddedTops, title: "Just added tops" })
   }
   if (data?.me?.savedItems?.length) {
     const results = data?.me?.savedItems?.map((item) => item?.productVariant?.product)

--- a/src/Scenes/Home/queries/homeQueries.ts
+++ b/src/Scenes/Home/queries/homeQueries.ts
@@ -148,6 +148,14 @@ export const GET_HOMEPAGE = gql`
         url
       }
     }
+    justAddedOuterwear: products(
+      first: 8
+      category: "outerwear"
+      orderBy: publishedAt_DESC
+      where: { AND: [{ variants_some: { id_not: null } }, { status: Available }, { tags_none: { name: "Vintage" } }] }
+    ) {
+      ...HomePageProduct
+    }
     justAddedTops: products(
       first: 8
       category: "tops"


### PR DESCRIPTION
Adds an outerwear rail to the home bottom sheet. Note that this retains the "Just added tops" section but pushed it below the "Designers" and "Recently Viewed" section.

[Asana ticket](https://app.asana.com/0/1193783406002247/1199003698951490)

<img width="200" alt="File_001" src="https://user-images.githubusercontent.com/5216744/98044520-07346780-1df5-11eb-96f2-9c4cc86cd31e.png">

