### PR TITLE
refetch GET_PLANS query after triage

### DIFF
--- a/src/Scenes/CreateAccount/Undetermined/TriagePane/TriagePane.tsx
+++ b/src/Scenes/CreateAccount/Undetermined/TriagePane/TriagePane.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from "react"
 import { useMutation } from "react-apollo"
 import * as Sentry from "@sentry/react-native"
 import { TriageProgressScreen } from "./TriageProgressScreen"
+import { GET_PLANS } from "../../CreateAccount"
 
 const TRIAGE = gql`
   mutation triage {
@@ -49,6 +50,12 @@ export const TriagePane: React.FC<TriagePaneProps> = ({ check, onTriageComplete 
       console.log("Error TriagePane.tsx:", err)
       showPopUp(errorPopUpData)
     },
+    refetchQueries: [
+      {
+        query: GET_PLANS,
+      },
+    ],
+    awaitRefetchQueries: true,
   })
 
   useEffect(() => {


### PR DESCRIPTION
Adds a refetch for the `GET_PLANS` query after we triage a customer. This is needed to:
- ensure we get the accurate value for `allAccessEnabled`
- ensure we get the customer's `referralLink`