### PR TITLE
Fix backspace behavior when searching contacts

### DIFF
--- a/src/Scenes/Account/InviteFriends/InviteFromContacts.tsx
+++ b/src/Scenes/Account/InviteFriends/InviteFromContacts.tsx
@@ -156,7 +156,7 @@ export const InviteFromContacts = screenTrack()(({ route, navigation }) => {
                     setSearchText(text)
                   }}
                   onKeyPress={({ nativeEvent }) => {
-                    if (nativeEvent.key === "Backspace") {
+                    if (nativeEvent.key === "Backspace" && searchText === "") {
                       setSelectedContact(null)
                     }
                   }}


### PR DESCRIPTION
## Changes

Backspace would delete contact whenever a backspace key occurs. We want this to only clear the selected contact if the search text is empty