### PR TITLE
fix: only advance to confirmation screen on order success

### DIFF
--- a/src/Scenes/Order/Order.tsx
+++ b/src/Scenes/Order/Order.tsx
@@ -49,9 +49,11 @@ export const Order = screenTrack()(({ route, navigation }) => {
 
       if (result.errors) {
         handleError((result.errors as any) as readonly ApolloError[])
+        return
       }
     } catch (e) {
       handleError(e)
+      return
     }
 
     navigation.navigate(NavigationSchema.PageNames.OrderConfirmation, {


### PR DESCRIPTION
Fixes a regression I introduced in #489, we only want to advance to the order confirmation screen on success.