### PR TITLE
show tracking meter when returning package

### DIFF
--- a/src/Scenes/Bag/Components/BagTabHeader.tsx
+++ b/src/Scenes/Bag/Components/BagTabHeader.tsx
@@ -106,8 +106,9 @@ export const BagTabHeader: React.FC<{
   const status = activeReservation?.status
   const subHeaderText = getSubHeaderText(me, activeReservation, atHome)
   const markedAsReturned = !!activeReservation?.returnedAt
+  const showDeliveryStatus = !!activeReservation && !atHome
+  const showMarkedAsReturnedInfo = markedAsReturned && !showDeliveryStatus
 
-  const showDeliveryStatus = !!activeReservation && !atHome && !markedAsReturned
   const showSubHeaderText = !markedAsReturned && !showDeliveryStatus && !!subHeaderText
 
   return (
@@ -141,7 +142,7 @@ export const BagTabHeader: React.FC<{
           </Sans>
         </Box>
       )}
-      {markedAsReturned && (
+      {showMarkedAsReturnedInfo && (
         <Box px={2}>
           <Sans size="4" color="black50">
             Your bag will update after UPS scans the return label. Second thoughts?{" "}
@@ -152,9 +153,9 @@ export const BagTabHeader: React.FC<{
             ) : (
               <Sans
                 size="4"
-                onPress={() => {
+                onPress={async () => {
                   setCancelingReturn(true)
-                  cancelReturn({
+                  await cancelReturn({
                     awaitRefetchQueries: true,
                     refetchQueries: [{ query: GetBag_NoCache_Query }],
                   })


### PR DESCRIPTION
We had a bug in the bag header wherein if `returnedAt` was set on the reservation, we wouldn't show the status meter while the package was in flight to us. This PR fixes it. I also went through all the states on a reservation and confirmed the bag tab header looked good.

## Correct
<img width="475" alt="Screen Shot 2021-08-10 at 1 49 45 PM" src="https://user-images.githubusercontent.com/5470676/128919757-2307b3e1-067d-4d6f-8e2c-516005235318.png">


## Incorrect
![image](https://user-images.githubusercontent.com/5470676/128919816-91033877-7724-47fe-a5d2-54f5db62c94c.png)

