### PR TITLE
Removes skeleton from CreditBalance

### DIFF
--- a/src/Scenes/Account/Account.tsx
+++ b/src/Scenes/Account/Account.tsx
@@ -4,8 +4,17 @@ import { useAuthContext } from "App/Navigation/AuthContext"
 import { Schema, screenTrack, useTracking } from "App/utils/track"
 import { ChevronIcon } from "Assets/icons"
 import {
-  DocumentWithText, Envelope, Instagram, LogOutSVG, ManageMembership, MapPin, MonocromeSeasonsLogo,
-  PersonalPreferences, PrivacyPolicy, SpeechBubble, Star
+  DocumentWithText,
+  Envelope,
+  Instagram,
+  LogOutSVG,
+  ManageMembership,
+  MapPin,
+  MonocromeSeasonsLogo,
+  PersonalPreferences,
+  PrivacyPolicy,
+  SpeechBubble,
+  Star,
 } from "Assets/svgs"
 import gql from "graphql-tag"
 import { DateTime } from "luxon"
@@ -264,7 +273,10 @@ export const Account = screenTrack()(() => {
     },
   ]
 
-  const renderBody = () => {
+  const BodyContent: React.FC = () => {
+    if (!status) {
+      return <ListSkeleton />
+    }
     switch (status) {
       case CustomerStatus.Created:
         return (
@@ -339,6 +351,8 @@ export const Account = screenTrack()(() => {
             detail="If you'd like to reactivate your account, please request access and we'll get back to you shortly."
           />
         )
+      default:
+        return <ListSkeleton />
     }
   }
 
@@ -369,7 +383,7 @@ export const Account = screenTrack()(() => {
           <CreditBalance membership={customer?.membership} />
           <InsetSeparator />
           <Box px={2} py={4}>
-            {!customer ? <ListSkeleton /> : renderBody()}
+            <BodyContent />
           </Box>
           <InsetSeparator />
           {!!referralLink && (

--- a/src/Scenes/Account/Components/CreditBalance.tsx
+++ b/src/Scenes/Account/Components/CreditBalance.tsx
@@ -33,18 +33,5 @@ export const CreditBalance = ({ membership }) => {
       </Flex>
       <Spacer mb={4} />
     </>
-  ) : (
-    <>
-      <Spacer mb={1} />
-      <Flex flexDirection="row" justifyContent="space-between" alignItems="flex-end" px={2} style={{ width: "100%" }}>
-        <Box>
-          <Skeleton width={88} height={20} />
-          <Spacer mt={2} />
-          <Skeleton width={133} height={20} />
-        </Box>
-        <Skeleton width={100} height={36} />
-      </Flex>
-      <Spacer mb={4} />
-    </>
-  )
+  ) : null
 }


### PR DESCRIPTION
- The `CreditBalance` component is designed to not appear if they've never had any promotional credits, which for the majority of customers going forward will be the case. If a customer has ever had promotional credits their credits will be a `number` and not `null` so the component will render