### PR TITLE
Adds recentlyViewedProducts directly from me resolver

### DIFF
--- a/src/Scenes/Home/Components/HomeBottomSheet.tsx
+++ b/src/Scenes/Home/Components/HomeBottomSheet.tsx
@@ -109,17 +109,12 @@ const sectionsFrom = (data: Homepage_Query_Type, dataNoCache: HomepageNoCache_Qu
     )
   }
 
-  if (data?.homepage?.sections?.length) {
-    sections.push(
-      ...data?.homepage?.sections
-        .map((section) => {
-          switch (section.type) {
-            case SectionType.Products:
-              return section
-          }
-        })
-        .filter(Boolean)
-    )
+  if (dataNoCache?.me?.recentlyViewedProducts?.length) {
+    sections.push({
+      type: SectionType.Products,
+      results: dataNoCache?.me?.recentlyViewedProducts,
+      title: "Recently viewed",
+    })
   }
 
   if (data?.upcomingProducts?.length > 0) {

--- a/src/Scenes/Home/queries/homeQueries.ts
+++ b/src/Scenes/Home/queries/homeQueries.ts
@@ -87,6 +87,23 @@ export const HomepageNoCache_Query = gql`
         shouldRequestFeedback
         ...CustomerTraitsFragment_Customer
       }
+      recentlyViewedProducts {
+        id
+        slug
+        images(size: Thumb) {
+          id
+          url
+        }
+        brand {
+          id
+          name
+        }
+        variants {
+          id
+          reservable
+          displayShort
+        }
+      }
       savedItems {
         id
         productVariant {
@@ -127,38 +144,6 @@ export const Homepage_Query = gql`
       caption
       type
       properties
-    }
-    # FIXME: Homepage query is only returning recently viewed, lets move it to a field resolver of its own
-    homepage {
-      sections {
-        id
-        title
-        type
-        tagData {
-          id
-          tagName
-          description
-        }
-        results {
-          ... on Product {
-            id
-            slug
-            images(size: Thumb) {
-              id
-              url
-            }
-            brand {
-              id
-              name
-            }
-            variants {
-              id
-              reservable
-              displayShort
-            }
-          }
-        }
-      }
     }
     featuredCollections: collections(orderBy: updatedAt_DESC, where: { published: true }, first: 5) {
       id


### PR DESCRIPTION
- Removes calls to the homepage resolver, which is now deprecated. The only remaining section used in the resolver was for fetching `recentlyViewedProducts` which is now in its own resolver on `me`
- Relies on Monsoon PR: https://github.com/seasons/monsoon/pull/1308